### PR TITLE
Change display name and description to match behavior.

### DIFF
--- a/src/main/java/hudson/markup/RawHtmlMarkupFormatter.java
+++ b/src/main/java/hudson/markup/RawHtmlMarkupFormatter.java
@@ -63,7 +63,7 @@ public class RawHtmlMarkupFormatter extends MarkupFormatter {
     public static class DescriptorImpl extends MarkupFormatterDescriptor {
         @Override
         public String getDisplayName() {
-            return "Raw HTML";
+            return "Safe HTML";
         }
     }
 

--- a/src/main/resources/hudson/markup/RawHtmlMarkupFormatter/config.properties
+++ b/src/main/resources/hudson/markup/RawHtmlMarkupFormatter/config.properties
@@ -1,2 +1,2 @@
-blurb=Treat the text as HTML and use it as is without any translation
+blurb=Treat the text as HTML and use it as is without any translation, but remove potentially unsafe elements like <code>&lt;script&gt;</code>.
 disableSyntaxHighlighting=Disable syntax highlighting


### PR DESCRIPTION
_Raw HTML_ sounds a lot like this should behave like anything-goes-formatter, while it doesn't. _Safe HTML_ captures the actual behavior much better.

Also noted the limitation on unsafe HTML in the description.
