### PR TITLE
[FIX JENKINS-31616] Prohibit scheme-relative URLs

### DIFF
--- a/src/main/java/hudson/markup/MyspacePolicy.java
+++ b/src/main/java/hudson/markup/MyspacePolicy.java
@@ -20,7 +20,7 @@ public class MyspacePolicy {
     public static final PolicyFactory POLICY_DEFINITION;
 
     private static final Pattern ONSITE_URL = Pattern.compile(
-        "(?:[\\p{L}\\p{N}\\\\\\.\\#@\\$%\\+&;\\-_~,\\?=/!]+|\\#(\\w)+)");
+        "(?!//)(?:[\\p{L}\\p{N}\\\\\\.\\#@\\$%\\+&;\\-_~,\\?=/!]+|\\#(\\w)+)");
     private static final Pattern OFFSITE_URL = Pattern.compile(
         "\\s*(?:(?:ht|f)tps?://|mailto:)[\\p{L}\\p{N}]"
         + "[\\p{L}\\p{N}\\p{Zs}\\.\\#@\\$%\\+&;:\\-_~,\\?=/!\\(\\)]*\\s*");

--- a/src/test/java/hudson/markup/MyspacePolicyTest.java
+++ b/src/test/java/hudson/markup/MyspacePolicyTest.java
@@ -48,6 +48,11 @@ public class MyspacePolicyTest extends Assert {
         assertReject("sun.com", "<form method='post' action='http://sun.com/'><input type='text' name='foo'><input type='password' name='pass'></form>");
     }
 
+    @Test
+    public void testProtocolRelativeUrl() {
+        assertReject("action", "<form action='//example.org/evil.php'><input type='submit'/></form>");
+    }
+
     private void assertIntact(String input) {
         input = input.replace('\'','\"');
         assertSanitize(input,input);


### PR DESCRIPTION
Don't consider URLs that start with `//` to be *onsite*.