### PR TITLE
[JENKINS-34511] Migrate to 2.7 parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.553</version>
+        <version>2.7</version>
     </parent>
     <artifactId>antisamy-markup-formatter</artifactId>
     <version>1.4-SNAPSHOT</version>
@@ -23,6 +23,12 @@
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
       <tag>HEAD</tag>
   </scm>
+  
+    <properties>
+      <jenkins.version>1.565.3</jenkins.version>
+      <java.level>6</java.level>
+    </properties>
+  
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
@@ -42,18 +48,4 @@
             <version>r88</version>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.1</version>
-                <configuration>
-                    <xmlOutput>true</xmlOutput>
-                    <findbugsXmlWithMessages>true</findbugsXmlWithMessages>
-                    <failOnError>false</failOnError>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
     Uses the <a href="https://www.owasp.org/index.php/OWASP_Java_HTML_Sanitizer_Project">OWASP Java HTML Sanitizer</a>
     to allow safe-seeming HTML markup to be entered in project descriptions and the like.


### PR DESCRIPTION
`InjectedTests` do not pass with baseline `1.533`, so it was bumped to `1.565.3`.

@reviewbybees 