### PR TITLE
java.lang.NoSuchMethodError: hudson.markup.Messages.EscapedMarkupFormatter_DisplayName()Ljava/lang/String;

### DIFF
--- a/src/main/resources/hudson/markup/Messages.properties
+++ b/src/main/resources/hudson/markup/Messages.properties
@@ -1,1 +1,0 @@
-RawHtmlMarkupFormatter.DisplayName=Safe HTML


### PR DESCRIPTION
After #12 I am getting

```
WARNING	hudson.ExtensionComponent#compareTo: Failure during Descriptor#getDisplayName for hudson.markup.EscapedMarkupFormatter$DescriptorImpl
java.lang.NoSuchMethodError: hudson.markup.Messages.EscapedMarkupFormatter_DisplayName()Ljava/lang/String;
	at hudson.markup.EscapedMarkupFormatter$DescriptorImpl.getDisplayName(EscapedMarkupFormatter.java:60)
	at hudson.ExtensionComponent.compareTo(ExtensionComponent.java:98)
	at hudson.ExtensionComponent.compareTo(ExtensionComponent.java:42)
	at java.util.ComparableTimSort.binarySort(ComparableTimSort.java:262)
	at java.util.ComparableTimSort.sort(ComparableTimSort.java:207)
	at java.util.Arrays.sort(Arrays.java:1312)
	at java.util.Arrays.sort(Arrays.java:1506)
	at java.util.ArrayList.sort(ArrayList.java:1462)
	at java.util.Collections.sort(Collections.java:143)
	at hudson.ExtensionList.sort(ExtensionList.java:401)
	at hudson.ExtensionList.ensureLoaded(ExtensionList.java:319)
	at …
```

because this plugin reintroduced a duplicate resource that clashes with one in Jenkins core. Anyway this message key was unused: https://github.com/jenkinsci/antisamy-markup-formatter-plugin/blob/d5f1a183d477e2d66b7f04f475b2608cef2f7a8f/src/main/java/hudson/markup/RawHtmlMarkupFormatter.java#L59