### PR TITLE
Allow <font>

### DIFF
--- a/src/main/java/hudson/markup/BasicPolicy.java
+++ b/src/main/java/hudson/markup/BasicPolicy.java
@@ -8,7 +8,7 @@ public class BasicPolicy {
     public static final PolicyFactory POLICY_DEFINITION;
 
 
-    public static final PolicyFactory ADDITIONS = new HtmlPolicyBuilder().allowElements("dl", "dt", "dd", "hr", "pre").toFactory();
+    public static final PolicyFactory ADDITIONS = new HtmlPolicyBuilder().allowElements("dl", "dt", "dd", "hr", "pre", "font").toFactory();
 
     static {
         POLICY_DEFINITION = Sanitizers.BLOCKS.


### PR DESCRIPTION
The font tag is highly used in our environment to set colors.  I don't know that the font tag could be inherently unsafe or why it was removed.