### PR TITLE
[JENKINS-55029] Allow target=_blank; add rel='noopener noreferrer'

### DIFF
--- a/src/main/java/hudson/markup/BasicPolicy.java
+++ b/src/main/java/hudson/markup/BasicPolicy.java
@@ -1,5 +1,7 @@
 package hudson.markup;
 
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.owasp.html.HtmlPolicyBuilder;
 import org.owasp.html.PolicyFactory;
 import org.owasp.html.Sanitizers;
@@ -7,8 +9,17 @@ import org.owasp.html.Sanitizers;
 public class BasicPolicy {
     public static final PolicyFactory POLICY_DEFINITION;
 
-
+    @Restricted(NoExternalUse.class)
     public static final PolicyFactory ADDITIONS = new HtmlPolicyBuilder().allowElements("dl", "dt", "dd", "hr", "pre").toFactory();
+
+    @Restricted(NoExternalUse.class)
+    public static final PolicyFactory LINK_TARGETS = new HtmlPolicyBuilder()
+            .allowElements("a")
+            .requireRelsOnLinks("noopener", "noreferrer")
+            .allowAttributes("target")
+            .matching(false, "_blank")
+            .onElements("a")
+            .toFactory();
 
     static {
         POLICY_DEFINITION = Sanitizers.BLOCKS.
@@ -17,6 +28,6 @@ public class BasicPolicy {
                 and(Sanitizers.LINKS).
                 and(Sanitizers.STYLES).
                 and(Sanitizers.TABLES).
-                and(ADDITIONS);
+                and(ADDITIONS).and(LINK_TARGETS);
     }
 }

--- a/src/test/java/hudson/markup/BasicPolicyTest.java
+++ b/src/test/java/hudson/markup/BasicPolicyTest.java
@@ -11,14 +11,27 @@ import java.io.IOException;
 public class BasicPolicyTest extends Assert {
     @Test
     public void testPolicy() {
-        assertSanitize("<a href='http://www.cloudbees.com' rel='nofollow'>CB</a>", "<a href='http://www.cloudbees.com'>CB</a>");
-        assertSanitize("<a href='relative/link' rel='nofollow'>relative</a>", "<a href='relative/link'>relative</a>");
-        assertSanitize("<a href='relative/link' rel='nofollow'>relative</a>", "<a href='relative/link' target='foo'>relative</a>");
+        assertSanitize("<a href='https://www.cloudbees.com' rel='nofollow noopener noreferrer'>CB</a>", "<a href='https://www.cloudbees.com'>CB</a>");
+        assertSanitize("<a href='https://www.cloudbees.com' rel='nofollow noopener noreferrer'>CB</a>", "<a href='https://www.cloudbees.com' target='foo'>CB</a>");
+        assertSanitize("<a href='https://www.cloudbees.com' target='_blank' rel='nofollow noopener noreferrer'>CB</a>", "<a href='https://www.cloudbees.com' target='_blank'>CB</a>");
 
-        // TODO arguable, see JENKINS-55029
-        assertSanitize("<a href='relative/link' rel='nofollow'>relative</a>", "<a href='relative/link' target='_blank'>relative</a>");
+        assertSanitize("<a href='relative/link' rel='nofollow noopener noreferrer'>relative</a>", "<a href='relative/link'>relative</a>");
+        assertSanitize("<a href='relative/link' rel='nofollow noopener noreferrer'>relative</a>", "<a href='relative/link' target='foo'>relative</a>");
+        assertSanitize("<a href='relative/link' target='_blank' rel='nofollow noopener noreferrer'>relative</a>", "<a href='relative/link' target='_blank'>relative</a>");
 
-        assertSanitize("<a href='mailto:kk&#64;kohsuke.org' rel='nofollow'>myself</a>", "<a href='mailto:kk&#64;kohsuke.org'>myself</a>");
+        assertSanitize("<a href='/link' rel='nofollow noopener noreferrer'>relative</a>", "<a href='/link'>relative</a>");
+        assertSanitize("<a href='/link' rel='nofollow noopener noreferrer'>relative</a>", "<a href='/link' target='foo'>relative</a>");
+        assertSanitize("<a href='/link' target='_blank' rel='nofollow noopener noreferrer'>relative</a>", "<a href='/link' target='_blank'>relative</a>");
+
+        assertSanitize("<a href='//www.cloudbees.com' rel='nofollow noopener noreferrer'>relative</a>", "<a href='//www.cloudbees.com'>relative</a>");
+        assertSanitize("<a href='//www.cloudbees.com' rel='nofollow noopener noreferrer'>relative</a>", "<a href='//www.cloudbees.com' target='foo'>relative</a>");
+        assertSanitize("<a href='//www.cloudbees.com' target='_blank' rel='nofollow noopener noreferrer'>relative</a>", "<a href='//www.cloudbees.com' target='_blank'>relative</a>");
+
+        assertSanitize("<a href='relative/link' rel='nofollow noopener noreferrer'>relative</a>", "<a href='relative/link' rel='noreferrer'>relative</a>");
+        assertSanitize("<a href='relative/link' rel='nofollow noopener noreferrer'>relative</a>", "<a href='relative/link' rel='noopener' target='foo'>relative</a>");
+        assertSanitize("<a href='relative/link' target='_blank' rel='nofollow noopener noreferrer'>relative</a>", "<a href='relative/link' rel='nofollow' target='_blank'>relative</a>");
+
+        assertSanitize("<a href='mailto:kk&#64;kohsuke.org' rel='nofollow noopener noreferrer'>myself</a>", "<a href='mailto:kk&#64;kohsuke.org'>myself</a>");
         assertReject("javascript","<a href='javascript:alert(5)'>test</a>");
 
         assertIntact("<img src='http://www.cloudbees.com' />");


### PR DESCRIPTION
See [JENKINS-55029](https://issues.jenkins.io/browse/JENKINS-55029).

Add support for `target="_blank"` in a safe manner by always adding `rel="noopener noreferrer"`.

While this could be improved by automatically making external links open in a new window, this seems like a reasonable start.