### PR TITLE
Exclude Guava from packaging -- use the one from the Core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,12 @@
             <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
             <artifactId>owasp-java-html-sanitizer</artifactId>
             <version>20211018.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- JCasC compatibility -->
         <dependency>


### PR DESCRIPTION
The BOM pulls the older Guava:11 version, because the bump to Guava 30+ was done in Jenkins 2.320.

So instead of using right now the bom-weekly, I'm excluding Guava so this change is backward compatible so the testing base is bigger.

## Before this change:

```sh
unzip -t target/antisamy-markup-formatter.hpi | grep -i guava
    testing: WEB-INF/lib/guava-11.0.1.jar   OK
```

## After this change
```sh
unzip -t target/antisamy-markup-formatter.hpi | grep -i guava
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
