### PR TITLE
Jenkinsfile: Check against 2.320+ with Guava:30 and Guice:5.x bumps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,7 @@ buildPlugin(configurations: [
     [platform: 'linux', jdk: '8'],
     [platform: 'linux', jdk: '11'],
     [platform: 'windows', jdk: '11'],
+
+    // More recent with Guava & Guice bumps, only Linux
+    [ platform: "linux", jdk: "8", jenkins: '2.324', javaLevel: "8" ],
 ])


### PR DESCRIPTION
* Guava got bumped from 11 to 30 in 2.320
* Also Guice got bumped from 4.0 to 5.0.1 in 2.321
* going for the currently latest 2.324 for https://github.com/jenkinsci/jenkins/pull/6014
