### PR TITLE
Upgrade parent pom to 4.40

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,5 +4,8 @@ buildPlugin(configurations: [
     [platform: 'windows', jdk: '11'],
 
     // More recent with Guava & Guice bumps, only Linux
-    [ platform: "linux", jdk: "8", jenkins: '2.324', javaLevel: "8" ],
+    [ platform: "linux", jdk: "8", jenkins: '2.324' ],
+
+    // Latest Java LTS
+    [ platform: 'linux', jdk: '17', jenkins: '2.348' ],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.33</version>
+        <version>4.40</version>
     </parent>
     <artifactId>antisamy-markup-formatter</artifactId>
     <version>${changelist}</version>
@@ -28,7 +28,6 @@
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/antisamy-markup-formatter-plugin</gitHubRepo>
         <jenkins.version>2.277.4</jenkins.version>
-        <java.level>8</java.level>
         <hpi.compatibleSinceVersion>2.0</hpi.compatibleSinceVersion>
     </properties>
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Updates parent pom to 4.40 ([release notes](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.40)) and removes the newly-unnecessary `java.level` property.

This enables testing on Java 17, using https://github.com/jenkinsci/timestamper-plugin/pull/167 as a model.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue (existing tests work)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

Fixes #71
Fixes #76