### PR TITLE
[JENKINS-60866] Valid JSON snippet to configure CodeMirror

### DIFF
--- a/src/main/java/hudson/markup/RawHtmlMarkupFormatter.java
+++ b/src/main/java/hudson/markup/RawHtmlMarkupFormatter.java
@@ -49,7 +49,7 @@ public class RawHtmlMarkupFormatter extends MarkupFormatter {
     }
 
     public String getCodeMirrorConfig() {
-        return "mode:'text/html'";
+        return "\"mode\":\"text/html\"";
     }
 
     @Extension


### PR DESCRIPTION
Core currently `eval`s the "JSON" string passed in as `codemirror-config` to `f:textarea`, but I want to change this in https://github.com/jenkinsci/jenkins/pull/6867. That requires proper quoting.

Origin branch, please delete on merge.