### PR TITLE
feat: allow title attribute on elements a and img

### DIFF
--- a/src/main/java/hudson/markup/BasicPolicy.java
+++ b/src/main/java/hudson/markup/BasicPolicy.java
@@ -23,6 +23,7 @@ public class BasicPolicy {
 
     @Restricted(NoExternalUse.class)
     public static final PolicyFactory TITLE_ATTRIBUTES = new HtmlPolicyBuilder()
+            .allowElements("a", "img")
             .allowAttributes("title")
             .onElements("a", "img")
             .toFactory();

--- a/src/main/java/hudson/markup/BasicPolicy.java
+++ b/src/main/java/hudson/markup/BasicPolicy.java
@@ -21,6 +21,7 @@ public class BasicPolicy {
             .onElements("a")
             .toFactory();
 
+    @Restricted(NoExternalUse.class)
     public static final PolicyFactory TITLE_ATTRIBUTES = new HtmlPolicyBuilder()
             .allowAttributes("title")
             .onElements("a", "img")

--- a/src/main/java/hudson/markup/BasicPolicy.java
+++ b/src/main/java/hudson/markup/BasicPolicy.java
@@ -21,6 +21,11 @@ public class BasicPolicy {
             .onElements("a")
             .toFactory();
 
+    public static final PolicyFactory TITLE_ATTRIBUTES = new HtmlPolicyBuilder()
+            .allowAttributes("title")
+            .onElements("a", "img")
+            .toFactory();
+
     static {
         POLICY_DEFINITION = Sanitizers.BLOCKS.
                 and(Sanitizers.FORMATTING).
@@ -28,6 +33,6 @@ public class BasicPolicy {
                 and(Sanitizers.LINKS).
                 and(Sanitizers.STYLES).
                 and(Sanitizers.TABLES).
-                and(ADDITIONS).and(LINK_TARGETS);
+                and(ADDITIONS).and(LINK_TARGETS).and(TITLE_ATTRIBUTES);
     }
 }

--- a/src/test/java/hudson/markup/BasicPolicyTest.java
+++ b/src/test/java/hudson/markup/BasicPolicyTest.java
@@ -30,7 +30,7 @@ public class BasicPolicyTest extends Assert {
         assertSanitize("<a href='relative/link' rel='nofollow noopener noreferrer'>relative</a>", "<a href='relative/link' rel='noopener' target='foo'>relative</a>");
         assertSanitize("<a href='relative/link' target='_blank' rel='nofollow noopener noreferrer'>relative</a>", "<a href='relative/link' rel='nofollow' target='_blank'>relative</a>");
 
-        assertSanitize("<a href='https://www.cloudbees.com' target='_blank' title='click me'>relative</a>", "<a href='https://www.cloudbees.com' target='_blank' title='click me'>relative</a>");
+        assertSanitize("<a href='https://www.cloudbees.com' target='_blank' title='click me' rel='nofollow noopener noreferrer'>relative</a>", "<a href='https://www.cloudbees.com' target='_blank' title='click me'>relative</a>");
 
         assertSanitize("<a href='mailto:kk&#64;kohsuke.org' rel='nofollow noopener noreferrer'>myself</a>", "<a href='mailto:kk&#64;kohsuke.org'>myself</a>");
         assertReject("javascript","<a href='javascript:alert(5)'>test</a>");

--- a/src/test/java/hudson/markup/BasicPolicyTest.java
+++ b/src/test/java/hudson/markup/BasicPolicyTest.java
@@ -30,12 +30,15 @@ public class BasicPolicyTest extends Assert {
         assertSanitize("<a href='relative/link' rel='nofollow noopener noreferrer'>relative</a>", "<a href='relative/link' rel='noopener' target='foo'>relative</a>");
         assertSanitize("<a href='relative/link' target='_blank' rel='nofollow noopener noreferrer'>relative</a>", "<a href='relative/link' rel='nofollow' target='_blank'>relative</a>");
 
+        assertSanitize("<a href='https://www.cloudbees.com' target='_blank' title='click me'>relative</a>", "<a href='https://www.cloudbees.com' target='_blank' title='click me'>relative</a>");
+
         assertSanitize("<a href='mailto:kk&#64;kohsuke.org' rel='nofollow noopener noreferrer'>myself</a>", "<a href='mailto:kk&#64;kohsuke.org'>myself</a>");
         assertReject("javascript","<a href='javascript:alert(5)'>test</a>");
 
         assertIntact("<img src='http://www.cloudbees.com' />");
         assertIntact("<img src='relative/test.png' />");
         assertIntact("<img src='relative/test.png' />");
+        assertIntact("<img src='relative/test.png' title='click me' />");
         assertReject("onerror","<img src='x' onerror='alert(5)'>");
         assertReject("javascript","<img src='javascript:alert(5)'>");
 
@@ -74,12 +77,12 @@ public class BasicPolicyTest extends Assert {
         input = input.replace('\'','\"');
         assertSanitize(input,input);
     }
-    
+
     private void assertReject(String problematic, String input) {
         String out = sanitize(input);
         assertFalse(out, out.contains(problematic));
     }
-    
+
     private void assertSanitize(String expected, String input) {
         assertEquals(expected.replace('\'','\"'),sanitize(input));
     }

--- a/src/test/java/hudson/markup/BasicPolicyTest.java
+++ b/src/test/java/hudson/markup/BasicPolicyTest.java
@@ -30,7 +30,7 @@ public class BasicPolicyTest extends Assert {
         assertSanitize("<a href='relative/link' rel='nofollow noopener noreferrer'>relative</a>", "<a href='relative/link' rel='noopener' target='foo'>relative</a>");
         assertSanitize("<a href='relative/link' target='_blank' rel='nofollow noopener noreferrer'>relative</a>", "<a href='relative/link' rel='nofollow' target='_blank'>relative</a>");
 
-        assertSanitize("<a href='https://www.cloudbees.com' rel='nofollow noopener noreferrer' title='click me'>relative</a>", "<a href='https://www.cloudbees.com' title='click me'>relative</a>");
+        assertSanitize("<a href='https://www.cloudbees.com' title='click me' rel='nofollow noopener noreferrer'>relative</a>", "<a href='https://www.cloudbees.com' title='click me'>relative</a>");
 
         assertSanitize("<a href='mailto:kk&#64;kohsuke.org' rel='nofollow noopener noreferrer'>myself</a>", "<a href='mailto:kk&#64;kohsuke.org'>myself</a>");
         assertReject("javascript","<a href='javascript:alert(5)'>test</a>");

--- a/src/test/java/hudson/markup/BasicPolicyTest.java
+++ b/src/test/java/hudson/markup/BasicPolicyTest.java
@@ -30,7 +30,7 @@ public class BasicPolicyTest extends Assert {
         assertSanitize("<a href='relative/link' rel='nofollow noopener noreferrer'>relative</a>", "<a href='relative/link' rel='noopener' target='foo'>relative</a>");
         assertSanitize("<a href='relative/link' target='_blank' rel='nofollow noopener noreferrer'>relative</a>", "<a href='relative/link' rel='nofollow' target='_blank'>relative</a>");
 
-        assertSanitize("<a href='https://www.cloudbees.com' target='_blank' rel='nofollow noopener noreferrer' title='click me'>relative</a>", "<a href='https://www.cloudbees.com' target='_blank' title='click me'>relative</a>");
+        assertSanitize("<a href='https://www.cloudbees.com' rel='nofollow noopener noreferrer' title='click me'>relative</a>", "<a href='https://www.cloudbees.com' title='click me'>relative</a>");
 
         assertSanitize("<a href='mailto:kk&#64;kohsuke.org' rel='nofollow noopener noreferrer'>myself</a>", "<a href='mailto:kk&#64;kohsuke.org'>myself</a>");
         assertReject("javascript","<a href='javascript:alert(5)'>test</a>");

--- a/src/test/java/hudson/markup/BasicPolicyTest.java
+++ b/src/test/java/hudson/markup/BasicPolicyTest.java
@@ -30,7 +30,7 @@ public class BasicPolicyTest extends Assert {
         assertSanitize("<a href='relative/link' rel='nofollow noopener noreferrer'>relative</a>", "<a href='relative/link' rel='noopener' target='foo'>relative</a>");
         assertSanitize("<a href='relative/link' target='_blank' rel='nofollow noopener noreferrer'>relative</a>", "<a href='relative/link' rel='nofollow' target='_blank'>relative</a>");
 
-        assertSanitize("<a href='https://www.cloudbees.com' target='_blank' title='click me' rel='nofollow noopener noreferrer'>relative</a>", "<a href='https://www.cloudbees.com' target='_blank' title='click me'>relative</a>");
+        assertSanitize("<a href='https://www.cloudbees.com' target='_blank' rel='nofollow noopener noreferrer' title='click me'>relative</a>", "<a href='https://www.cloudbees.com' target='_blank' title='click me'>relative</a>");
 
         assertSanitize("<a href='mailto:kk&#64;kohsuke.org' rel='nofollow noopener noreferrer'>myself</a>", "<a href='mailto:kk&#64;kohsuke.org'>myself</a>");
         assertReject("javascript","<a href='javascript:alert(5)'>test</a>");

--- a/src/test/java/hudson/markup/BasicPolicyTest.java
+++ b/src/test/java/hudson/markup/BasicPolicyTest.java
@@ -30,7 +30,7 @@ public class BasicPolicyTest extends Assert {
         assertSanitize("<a href='relative/link' rel='nofollow noopener noreferrer'>relative</a>", "<a href='relative/link' rel='noopener' target='foo'>relative</a>");
         assertSanitize("<a href='relative/link' target='_blank' rel='nofollow noopener noreferrer'>relative</a>", "<a href='relative/link' rel='nofollow' target='_blank'>relative</a>");
 
-        assertSanitize("<a href='https://www.cloudbees.com' title='click me' rel='nofollow noopener noreferrer'>relative</a>", "<a href='https://www.cloudbees.com' title='click me'>relative</a>");
+        assertSanitize("<a href='https://www.cloudbees.com' rel='nofollow noopener noreferrer' title='click me'>relative</a>", "<a href='https://www.cloudbees.com' title='click me'>relative</a>");
 
         assertSanitize("<a href='mailto:kk&#64;kohsuke.org' rel='nofollow noopener noreferrer'>myself</a>", "<a href='mailto:kk&#64;kohsuke.org'>myself</a>");
         assertReject("javascript","<a href='javascript:alert(5)'>test</a>");


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This feature allows the `title` attribute on HTML elements like `a` and `img`.

_This will allow us to show some clickable links and icons in the build description in our pipelines._

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
