### PR TITLE
Modernize plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ https://github.com/jenkins-infra/pipeline-library/
 
 */
 buildPlugin(
+  forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
     [platform: 'linux', jdk: 21],

--- a/pom.xml
+++ b/pom.xml
@@ -1,82 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>4.86</version>
-        <relativePath />
-    </parent>
-    <artifactId>antisamy-markup-formatter</artifactId>
-    <version>${changelist}</version>
-    <packaging>hpi</packaging>
-    <name>OWASP Markup Formatter Plugin</name>
-    <description>Sanitize HTML markup in user-submitted text to be displayed on the Jenkins UI.</description>
-    <url>https://github.com/jenkinsci/antisamy-markup-formatter-plugin</url>
-    <licenses>
-        <license>
-            <name>MIT</name>
-            <url>https://opensource.org/licenses/MIT</url>
-        </license>
-    </licenses>
-    <scm>
-        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
-        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
-        <url>https://github.com/${gitHubRepo}</url>
-        <tag>${scmTag}</tag>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>5.4</version>
+    <relativePath />
+  </parent>
+
+  <artifactId>antisamy-markup-formatter</artifactId>
+  <version>${changelist}</version>
+  <packaging>hpi</packaging>
+
+  <name>OWASP Markup Formatter Plugin</name>
+  <description>Sanitize HTML markup in user-submitted text to be displayed on the Jenkins UI.</description>
+  <url>https://github.com/jenkinsci/antisamy-markup-formatter-plugin</url>
+
+  <licenses>
+    <license>
+      <name>MIT</name>
+      <url>https://opensource.org/licenses/MIT</url>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <tag>${scmTag}</tag>
+    <url>https://github.com/${gitHubRepo}</url>
   </scm>
 
-    <properties>
-        <changelist>999999-SNAPSHOT</changelist>
-        <gitHubRepo>jenkinsci/antisamy-markup-formatter-plugin</gitHubRepo>
-        <jenkins.version>2.440.3</jenkins.version>
-        <hpi.compatibleSinceVersion>2.0</hpi.compatibleSinceVersion>
-    </properties>
+  <properties>
+    <changelist>999999-SNAPSHOT</changelist>
+    <gitHubRepo>jenkinsci/antisamy-markup-formatter-plugin</gitHubRepo>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <spotless.check.skip>false</spotless.check.skip>
+    <hpi.compatibleSinceVersion>2.0</hpi.compatibleSinceVersion>
+  </properties>
 
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.440.x</artifactId>
-                <version>3234.v5ca_5154341ef</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+  <dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
-            <artifactId>owasp-java-html-sanitizer</artifactId>
-            <version>20220608.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!-- JCasC compatibility -->
-        <dependency>
-            <groupId>io.jenkins</groupId>
-            <artifactId>configuration-as-code</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.jenkins.configuration-as-code</groupId>
-            <artifactId>test-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+        <version>3850.vb_c5319efa_e29</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+      <artifactId>owasp-java-html-sanitizer</artifactId>
+      <version>20240325.1</version>
+    </dependency>
+    <!-- JCasC compatibility -->
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/src/main/java/hudson/markup/BasicPolicy.java
+++ b/src/main/java/hudson/markup/BasicPolicy.java
@@ -7,10 +7,10 @@ import org.owasp.html.PolicyFactory;
 import org.owasp.html.Sanitizers;
 
 public class BasicPolicy {
-    public static final PolicyFactory POLICY_DEFINITION;
 
     @Restricted(NoExternalUse.class)
-    public static final PolicyFactory ADDITIONS = new HtmlPolicyBuilder().allowElements("dl", "dt", "dd", "hr", "pre").toFactory();
+    public static final PolicyFactory ADDITIONS =
+            new HtmlPolicyBuilder().allowElements("dl", "dt", "dd", "hr", "pre").toFactory();
 
     @Restricted(NoExternalUse.class)
     public static final PolicyFactory LINK_TARGETS = new HtmlPolicyBuilder()
@@ -21,13 +21,16 @@ public class BasicPolicy {
             .onElements("a")
             .toFactory();
 
-    static {
-        POLICY_DEFINITION = Sanitizers.BLOCKS.
-                and(Sanitizers.FORMATTING).
-                and(Sanitizers.IMAGES).
-                and(Sanitizers.LINKS).
-                and(Sanitizers.STYLES).
-                and(Sanitizers.TABLES).
-                and(ADDITIONS).and(LINK_TARGETS);
+    public static final PolicyFactory POLICY_DEFINITION = Sanitizers.BLOCKS
+            .and(Sanitizers.FORMATTING)
+            .and(Sanitizers.IMAGES)
+            .and(Sanitizers.LINKS)
+            .and(Sanitizers.STYLES)
+            .and(Sanitizers.TABLES)
+            .and(ADDITIONS)
+            .and(LINK_TARGETS);
+
+    private BasicPolicy() {
+        // hidden
     }
 }

--- a/src/main/java/hudson/markup/RawHtmlMarkupFormatter.java
+++ b/src/main/java/hudson/markup/RawHtmlMarkupFormatter.java
@@ -1,24 +1,26 @@
 package hudson.markup;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import java.io.IOException;
+import java.io.Writer;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.owasp.html.Handler;
 import org.owasp.html.HtmlSanitizer;
 import org.owasp.html.HtmlStreamRenderer;
 
-import java.io.IOException;
-import java.io.Writer;
-
 /**
  * {@link MarkupFormatter} that sanitizes HTML, allowing some safe (formatting) HTML.
- *
+ * <p>
  * Before SECURITY-26 was fixed in Jenkins 1.454, this allowed all HTML without restriction.
  * Since then, the class name is a misnomer, but kept for backwards compatibility.
  *
  */
 public class RawHtmlMarkupFormatter extends MarkupFormatter {
 
-    final boolean disableSyntaxHighlighting;
+    public static final MarkupFormatter INSTANCE = new RawHtmlMarkupFormatter(false);
+
+    private final boolean disableSyntaxHighlighting;
 
     @DataBoundConstructor
     public RawHtmlMarkupFormatter(final boolean disableSyntaxHighlighting) {
@@ -30,7 +32,7 @@ public class RawHtmlMarkupFormatter extends MarkupFormatter {
     }
 
     @Override
-    public void translate(String markup, Writer output) throws IOException {
+    public void translate(String markup, @NonNull Writer output) throws IOException {
         HtmlStreamRenderer renderer = HtmlStreamRenderer.create(
                 output,
                 // Receives notifications on a failure to write to the output.
@@ -39,8 +41,7 @@ public class RawHtmlMarkupFormatter extends MarkupFormatter {
                 // truly bizarre inputs.
                 x -> {
                     throw new Error(x);
-                }
-        );
+                });
         HtmlSanitizer.sanitize(markup, BasicPolicy.POLICY_DEFINITION.apply(renderer));
     }
 
@@ -54,11 +55,11 @@ public class RawHtmlMarkupFormatter extends MarkupFormatter {
 
     @Extension
     public static class DescriptorImpl extends MarkupFormatterDescriptor {
+
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Safe HTML";
         }
     }
-
-    public static final MarkupFormatter INSTANCE = new RawHtmlMarkupFormatter(false);
 }

--- a/src/main/resources/hudson/markup/RawHtmlMarkupFormatter/config.jelly
+++ b/src/main/resources/hudson/markup/RawHtmlMarkupFormatter/config.jelly
@@ -1,4 +1,3 @@
-<!-- no config -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:description>

--- a/src/test/java/hudson/markup/BasicPolicyTest.java
+++ b/src/test/java/hudson/markup/BasicPolicyTest.java
@@ -1,43 +1,78 @@
 package hudson.markup;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.owasp.html.HtmlSanitizer;
-import org.owasp.html.HtmlStreamRenderer;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
+import org.junit.jupiter.api.Test;
 
-public class BasicPolicyTest extends Assert {
+class BasicPolicyTest {
+
+    private static final RawHtmlMarkupFormatter MARKUP_FORMATTER = new RawHtmlMarkupFormatter(false);
+
     @Test
-    public void testPolicy() {
-        assertSanitize("<a href='https://www.cloudbees.com' rel='nofollow noopener noreferrer'>CB</a>", "<a href='https://www.cloudbees.com'>CB</a>");
-        assertSanitize("<a href='https://www.cloudbees.com' rel='nofollow noopener noreferrer'>CB</a>", "<a href='https://www.cloudbees.com' target='foo'>CB</a>");
-        assertSanitize("<a href='https://www.cloudbees.com' target='_blank' rel='nofollow noopener noreferrer'>CB</a>", "<a href='https://www.cloudbees.com' target='_blank'>CB</a>");
+    void testPolicy() {
+        assertSanitize(
+                "<a href='https://www.cloudbees.com' rel='nofollow noopener noreferrer'>CB</a>",
+                "<a href='https://www.cloudbees.com'>CB</a>");
+        assertSanitize(
+                "<a href='https://www.cloudbees.com' rel='nofollow noopener noreferrer'>CB</a>",
+                "<a href='https://www.cloudbees.com' target='foo'>CB</a>");
+        assertSanitize(
+                "<a href='https://www.cloudbees.com' target='_blank' rel='nofollow noopener noreferrer'>CB</a>",
+                "<a href='https://www.cloudbees.com' target='_blank'>CB</a>");
 
-        assertSanitize("<a href='relative/link' rel='nofollow noopener noreferrer'>relative</a>", "<a href='relative/link'>relative</a>");
-        assertSanitize("<a href='relative/link' rel='nofollow noopener noreferrer'>relative</a>", "<a href='relative/link' target='foo'>relative</a>");
-        assertSanitize("<a href='relative/link' target='_blank' rel='nofollow noopener noreferrer'>relative</a>", "<a href='relative/link' target='_blank'>relative</a>");
+        assertSanitize(
+                "<a href='relative/link' rel='nofollow noopener noreferrer'>relative</a>",
+                "<a href='relative/link'>relative</a>");
+        assertSanitize(
+                "<a href='relative/link' rel='nofollow noopener noreferrer'>relative</a>",
+                "<a href='relative/link' target='foo'>relative</a>");
+        assertSanitize(
+                "<a href='relative/link' target='_blank' rel='nofollow noopener noreferrer'>relative</a>",
+                "<a href='relative/link' target='_blank'>relative</a>");
 
-        assertSanitize("<a href='/link' rel='nofollow noopener noreferrer'>relative</a>", "<a href='/link'>relative</a>");
-        assertSanitize("<a href='/link' rel='nofollow noopener noreferrer'>relative</a>", "<a href='/link' target='foo'>relative</a>");
-        assertSanitize("<a href='/link' target='_blank' rel='nofollow noopener noreferrer'>relative</a>", "<a href='/link' target='_blank'>relative</a>");
+        assertSanitize(
+                "<a href='/link' rel='nofollow noopener noreferrer'>relative</a>", "<a href='/link'>relative</a>");
+        assertSanitize(
+                "<a href='/link' rel='nofollow noopener noreferrer'>relative</a>",
+                "<a href='/link' target='foo'>relative</a>");
+        assertSanitize(
+                "<a href='/link' target='_blank' rel='nofollow noopener noreferrer'>relative</a>",
+                "<a href='/link' target='_blank'>relative</a>");
 
-        assertSanitize("<a href='//www.cloudbees.com' rel='nofollow noopener noreferrer'>relative</a>", "<a href='//www.cloudbees.com'>relative</a>");
-        assertSanitize("<a href='//www.cloudbees.com' rel='nofollow noopener noreferrer'>relative</a>", "<a href='//www.cloudbees.com' target='foo'>relative</a>");
-        assertSanitize("<a href='//www.cloudbees.com' target='_blank' rel='nofollow noopener noreferrer'>relative</a>", "<a href='//www.cloudbees.com' target='_blank'>relative</a>");
+        assertSanitize(
+                "<a href='//www.cloudbees.com' rel='nofollow noopener noreferrer'>relative</a>",
+                "<a href='//www.cloudbees.com'>relative</a>");
+        assertSanitize(
+                "<a href='//www.cloudbees.com' rel='nofollow noopener noreferrer'>relative</a>",
+                "<a href='//www.cloudbees.com' target='foo'>relative</a>");
+        assertSanitize(
+                "<a href='//www.cloudbees.com' target='_blank' rel='nofollow noopener noreferrer'>relative</a>",
+                "<a href='//www.cloudbees.com' target='_blank'>relative</a>");
 
-        assertSanitize("<a href='relative/link' rel='nofollow noopener noreferrer'>relative</a>", "<a href='relative/link' rel='noreferrer'>relative</a>");
-        assertSanitize("<a href='relative/link' rel='nofollow noopener noreferrer'>relative</a>", "<a href='relative/link' rel='noopener' target='foo'>relative</a>");
-        assertSanitize("<a href='relative/link' target='_blank' rel='nofollow noopener noreferrer'>relative</a>", "<a href='relative/link' rel='nofollow' target='_blank'>relative</a>");
+        assertSanitize(
+                "<a href='relative/link' rel='nofollow noopener noreferrer'>relative</a>",
+                "<a href='relative/link' rel='noreferrer'>relative</a>");
+        assertSanitize(
+                "<a href='relative/link' rel='nofollow noopener noreferrer'>relative</a>",
+                "<a href='relative/link' rel='noopener' target='foo'>relative</a>");
+        assertSanitize(
+                "<a href='relative/link' target='_blank' rel='nofollow noopener noreferrer'>relative</a>",
+                "<a href='relative/link' rel='nofollow' target='_blank'>relative</a>");
 
-        assertSanitize("<a href='mailto:kk&#64;kohsuke.org' rel='nofollow noopener noreferrer'>myself</a>", "<a href='mailto:kk&#64;kohsuke.org'>myself</a>");
-        assertReject("javascript","<a href='javascript:alert(5)'>test</a>");
+        assertSanitize(
+                "<a href='mailto:kk&#64;kohsuke.org' rel='nofollow noopener noreferrer'>myself</a>",
+                "<a href='mailto:kk&#64;kohsuke.org'>myself</a>");
+        assertReject("javascript", "<a href='javascript:alert(5)'>test</a>");
 
         assertIntact("<img src='http://www.cloudbees.com' />");
         assertIntact("<img src='relative/test.png' />");
         assertIntact("<img src='relative/test.png' />");
-        assertReject("onerror","<img src='x' onerror='alert(5)'>");
-        assertReject("javascript","<img src='javascript:alert(5)'>");
+        assertReject("onerror", "<img src='x' onerror='alert(5)'>");
+        assertReject("javascript", "<img src='javascript:alert(5)'>");
 
         assertIntact("<b><i><u><strike>basic tag</strike></u></i></b>");
         assertIntact("<div><p>basic block tags</p></div>");
@@ -51,9 +86,9 @@ public class BasicPolicyTest extends Assert {
 
         assertReject("iframe", "<iframe src='nested'></iframe>");
 
-        assertReject("script","<script>window.alert(5);</script>");
-        assertReject("script","<script src='http://foo/evil.js'></script>");
-        assertReject("script","<script src='relative.js'></script>");
+        assertReject("script", "<script>window.alert(5);</script>");
+        assertReject("script", "<script src='http://foo/evil.js'></script>");
+        assertReject("script", "<script src='relative.js'></script>");
 
         assertReject("form", "<form/>");
 
@@ -62,33 +97,47 @@ public class BasicPolicyTest extends Assert {
         assertIntact("<div style='background-color:white'>inline CSS</div>");
         assertIntact("<br /><hr />");
 
-        assertReject("sun.com", "<form method='post' action='http://sun.com/'><input type='text' name='foo'><input type='password' name='pass'></form>");
+        assertReject(
+                "sun.com",
+                "<form method='post' action='http://sun.com/'><input type='text' name='foo'><input type='password' name='pass'></form>");
     }
 
     @Test
-    public void testProtocolRelativeUrl() {
+    void testProtocolRelativeUrl() {
         assertReject("action", "<form action='//example.org/evil.php'><input type='submit'/></form>");
     }
 
-    private void assertIntact(String input) {
-        input = input.replace('\'','\"');
-        assertSanitize(input,input);
-    }
-    
-    private void assertReject(String problematic, String input) {
-        String out = sanitize(input);
-        assertFalse(out, out.contains(problematic));
-    }
-    
-    private void assertSanitize(String expected, String input) {
-        assertEquals(expected.replace('\'','\"'),sanitize(input));
+    private static void assertIntact(String input) {
+        input = input.replace('\'', '\"');
+        assertSanitize(input, input);
     }
 
-    private String sanitize(String input) {
+    private static void assertReject(String problematic, String input) {
+        String out = sanitize(input);
+        assertFalse(out.contains(problematic), out);
+    }
+
+    private static void assertSanitize(String expected, String input) {
+        expected = expected.replace('\'', '\"');
+        String sanitizedHtml = sanitize(input);
+
+        // https://github.com/OWASP/java-html-sanitizer/issues/336
+        if (input.contains("<a") && expected.contains("rel=")) {
+            assertTrue(sanitizedHtml.contains("noopener"));
+            assertTrue(sanitizedHtml.contains("noreferrer"));
+            assertTrue(sanitizedHtml.contains("nofollow"));
+
+            sanitizedHtml = sanitizedHtml.replaceAll("rel=\".+ .+ .+\"", "rel=\"nofollow noopener noreferrer\"");
+        }
+
+        assertEquals(expected, sanitizedHtml);
+    }
+
+    private static String sanitize(String input) {
         try {
-            return new RawHtmlMarkupFormatter(false).translate(input);
+            return MARKUP_FORMATTER.translate(input);
         } catch (IOException ex) {
-            throw new AssertionError(ex);
+            return fail(ex);
         }
     }
 }

--- a/src/test/java/hudson/markup/JCasCCompatibilityTest.java
+++ b/src/test/java/hudson/markup/JCasCCompatibilityTest.java
@@ -1,22 +1,24 @@
 package hudson.markup;
 
+import static org.junit.Assert.assertTrue;
+
 import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
 import jenkins.model.Jenkins;
-import org.junit.Assert;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 
 public class JCasCCompatibilityTest extends RoundTripAbstractTest {
 
     @Override
     protected void assertConfiguredAsExpected(RestartableJenkinsRule restartableJenkinsRule, String s) {
-        final Jenkins jenkins = restartableJenkinsRule.j.jenkins;
+        Jenkins jenkins = restartableJenkinsRule.j.jenkins;
 
-        Assert.assertTrue("Safe HTML markup formatter should be configured", jenkins.getMarkupFormatter() instanceof RawHtmlMarkupFormatter);
+        assertTrue(
+                "Safe HTML markup formatter should be configured",
+                jenkins.getMarkupFormatter() instanceof RawHtmlMarkupFormatter);
     }
 
     @Override
     protected String stringInLogExpected() {
         return "Setting class hudson.markup.RawHtmlMarkupFormatter.disableSyntaxHighlighting = true";
     }
-
 }


### PR DESCRIPTION
Modernize the plugin, including the following changes:

* bump plugin pom version
* set baseline to 2.479
* bump bom version
* enable spotless
* pom matches archetype
* Jenkinsfile matches archetype
* bump owasp-java-html-sanitizer version
* trivial code cleanup
* format sources with spotless
* migrate tests to JUnit5
* fix order of rel attribute for links in tests (required due to https://github.com/OWASP/java-html-sanitizer/issues/336)

Supersedes #121 #127 #128

### Testing done

Validated with `mvn clean verify`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
