### PR TITLE
Test core PR #26600

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <jenkins.version>2.559-rc38146.1a_b_5a_6588fe1</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
     <hpi.compatibleSinceVersion>2.0</hpi.compatibleSinceVersion>
   </properties>

--- a/src/test/java/hudson/markup/ClasspathRealTest.java
+++ b/src/test/java/hudson/markup/ClasspathRealTest.java
@@ -1,0 +1,45 @@
+package hudson.markup;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jenkins.core.PluginExcerptSanitizer;
+import jenkins.model.Jenkins;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.RealJenkinsRule;
+
+public class ClasspathRealTest {
+    public static final String CLASS_NAME = "org.owasp.shim.ForJava9AndLater";
+
+    @Rule
+    public RealJenkinsRule j = new RealJenkinsRule();
+
+    @Test
+    public void testClasspath() throws Throwable {
+        j.then(ClasspathRealTest::_testClasspath);
+    }
+
+    static void _testClasspath(JenkinsRule j) throws ClassNotFoundException {
+        assertThrows(
+                ClassNotFoundException.class,
+                () -> BasicPolicy.class.getClassLoader().loadClass(CLASS_NAME));
+        assertThrows(
+                ClassNotFoundException.class,
+                () -> ClasspathRealTest.class.getClassLoader().loadClass(CLASS_NAME));
+        // control:
+        Jenkins.get()
+                .getCoreLibrary(jenkins.core.PluginExcerptSanitizer.class)
+                .getClass()
+                .getClassLoader()
+                .loadClass(CLASS_NAME);
+
+        // control:
+        final PluginExcerptSanitizer sanitizer = Jenkins.get().getCoreLibrary(PluginExcerptSanitizer.class);
+        assertThat(
+                sanitizer.sanitize("<p><strong>Hello world</strong></p><script>alert(1);</script>"),
+                equalTo("<strong>Hello world</strong>"));
+    }
+}

--- a/src/test/java/hudson/markup/ClasspathTest.java
+++ b/src/test/java/hudson/markup/ClasspathTest.java
@@ -1,0 +1,33 @@
+package hudson.markup;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jenkins.core.PluginExcerptSanitizer;
+import jenkins.model.Jenkins;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+public class ClasspathTest {
+
+    public static final String CLASS_NAME = "org.owasp.shim.ForJava9AndLater";
+
+    @Test
+    public void testClasspath(JenkinsRule j) {
+        assertThrows(
+                ClassNotFoundException.class,
+                () -> BasicPolicy.class.getClassLoader().loadClass(CLASS_NAME));
+        assertThrows(
+                ClassNotFoundException.class,
+                () -> ClasspathTest.class.getClassLoader().loadClass(CLASS_NAME));
+
+        // control:
+        final PluginExcerptSanitizer sanitizer = Jenkins.get().getCoreLibrary(PluginExcerptSanitizer.class);
+        assertThat(
+                sanitizer.sanitize("<p><strong>Hello world</strong></p><script>alert(1);</script>"),
+                equalTo("<strong>Hello world</strong>"));
+    }
+}


### PR DESCRIPTION
This PR demonstrates (until the OWASP Java HTML Sanitizer update is integrated) that the plugin cannot load classes bundled as a "core" library for https://github.com/jenkinsci/jenkins/pull/26600.

Not to be merged.